### PR TITLE
Python codes translated from Matlab/Octave snippets

### DIFF
--- a/PythonCodeSnippets/snip_signals_peak_detection.py
+++ b/PythonCodeSnippets/snip_signals_peak_detection.py
@@ -1,0 +1,26 @@
+import numpy as np
+from matplotlib import pyplot as plt
+from scipy import signal
+
+dataset_filename = '../Applications/SignalFiles/sunspot.dat'
+
+sunspot = np.loadtxt(dataset_filename)
+
+year = sunspot[:, 0]
+wolfer = sunspot[:, 1]
+
+# plot(year,wolfer)
+plt.title('Sunspot Data')  # plot raw data
+x = wolfer - np.mean(wolfer)  # remove mean
+R = signal.correlate(x, x, mode="full")
+lags = signal.correlation_lags(x.size, x.size, mode="full")
+plt.plot(lags, R)
+index = np.where(lags == 11)[0][0]  # %we know the 2nd peak is lag=11
+plt.plot(lags[index], R[index], 'r.', 25)
+plt.annotate(
+    '2nd peak at lag=11',
+    xy=(lags[index], R[index]),
+    xytext=(100, 20*10e3),
+    arrowprops=dict(arrowstyle="->", facecolor='black'),
+    horizontalalignment='center', verticalalignment='bottom')
+plt.show()

--- a/PythonCodeSnippets/snip_systems_Msequence_chan_est.py
+++ b/PythonCodeSnippets/snip_systems_Msequence_chan_est.py
@@ -1,0 +1,35 @@
+import numpy as np
+from scipy.signal import max_len_seq
+
+h = np.transpose([-4+1j, -3, -2-1j])  # channel, column vector
+Nh = len(h)  # channel impulse response length
+Nx = 15  # number of samples of training sequence
+
+# training sequence (a maximum length sequence)
+x = max_len_seq(
+                4,
+                taps=[3]
+                )[0]*2-1
+
+alpha = 1/np.sum(x**2)  # 1/alpha is the value of autocorrelation R(0)
+y = np.convolve(h, x)  # input signal passes through the channel
+
+# Channel estimation and synchronization
+z = np.convolve(y, np.flipud(x))  # use convolution to mimic correlation, or
+# alternatively, one could use z=xcorr(y,conj(x)); and to make exactly
+# equivalent to conv extract part of result: z=z(end-2*Nx-Nh+3:end);
+max_output = np.max(np.abs(z))  # find peak of output (R)
+max_index = np.argmax(np.abs(z))  # find the index of output (R)
+h_est = alpha*z[max_index: max_index+Nh]  # estimated channel (postcursor)
+MSE = np.mean(np.abs(h-h_est)**2)  # estimation error
+NMSE = 10*np.log10(MSE/np.mean(np.abs(h)**2))  # normalized MSE in dB
+
+# Compare with theoretical values
+R = np.correlate(x, x, "full")  # autocorrelation
+z2 = np.convolve(R, h)  # conceptually, this is what we are doing to get z
+z_error = np.max(np.abs(z - z2))  # note that z is equal to z2
+
+print(f'Original channel: {h}')
+print(f'Estimated channel: {h_est}')
+print(f'NMSE (dB): {NMSE} dB')
+print(f'Z error: {z_error}')

--- a/PythonCodeSnippets/snip_systems_Msequence_step2.py
+++ b/PythonCodeSnippets/snip_systems_Msequence_step2.py
@@ -1,0 +1,6 @@
+def M_sequence_step_2(z, z2, R, maxIndex, h, max_R):
+    z[maxIndex]*max_R
+    z2[4094+1]*max_R
+    R[4094+1]*h[0+1]+R[4093+1]*h[1+1]+R[4092+1]*h[2+1]
+
+    return z, z2, R

--- a/PythonCodeSnippets/snip_systems_Msequence_step3.py
+++ b/PythonCodeSnippets/snip_systems_Msequence_step3.py
@@ -1,0 +1,12 @@
+import numpy as np
+from scipy.linalg import convolution_matrix
+
+
+def M_sequence_step_3(max_index, h, M, R, max_R):
+    Rsegment = R[max_index - M, max_index + M]/max_R  # segment of R
+    X = convolution_matrix(Rsegment, len(h))  # convolution matrix
+    z3 = X*h  # convolution center of z3 is equal to center of z
+    h_hat2 = z3[M+1:2*M+1]  # equal to h_hat
+    A = np.tranpose(X)*X  # note it is approximately the identity matrix
+
+    return h_hat2, A

--- a/PythonCodeSnippets/snip_systems_ak_convolution.py
+++ b/PythonCodeSnippets/snip_systems_ak_convolution.py
@@ -1,0 +1,41 @@
+from matplotlib import pyplot as plt
+import numpy as np
+
+
+def ak_convolution2(first_seq, second_seq,
+                    start_idx_first_seq, start_idx_second_seq):
+    N1 = len(first_seq)  # get the number of samples in the first sequence
+    N2 = len(second_seq)  # get the number of samples in the second sequence
+    N = N1 + N2 - 1
+    y = np.zeros(N)  # pre-allocate space for y[n]
+
+    for i in range(N1):
+        for j in range(N2):  # calculate y[n] = sum_k x1[k] x2[n-k]
+            y[i+j] = y[i+j] + first_seq[i]*second_seq[j]
+
+    time_index = np.arange(start_idx_first_seq + start_idx_second_seq,
+                           start_idx_first_seq + start_idx_second_seq + N)
+
+    return y, time_index
+
+
+x1 = np.arange(1, 4)  # define sequence x1
+x2 = np.arange(5, 9)  # define sequence x2
+x1_axis = np.arange(-3, 0)  # define abscissa for x1
+x2_axis = np.arange(2, 6)  # define abscissa for x2
+
+plt.tight_layout()
+plt.subplots_adjust(hspace=0.4)
+plt.subplot(311)
+plt.ylim([0, 4])
+plt.title('Discrete Convolution')
+plt.stem(x1_axis, x1)
+plt.subplot(312)
+plt.stem(x2_axis, x2)
+
+# calculate convolution
+y, n = ak_convolution2(x1, x2, x1_axis[0], x2_axis[0])
+plt.subplot(313)
+plt.xlabel('$n$')
+plt.stem(n, y, 'g')  # show result with proper time axis
+plt.show()

--- a/PythonCodeSnippets/snip_systems_continuous_discrete_conv.py
+++ b/PythonCodeSnippets/snip_systems_continuous_discrete_conv.py
@@ -1,0 +1,31 @@
+import numpy as np
+from matplotlib import pyplot as plt
+
+T0 = 0.2  # pulse "duty cycle" (interval with non-zero amplitude): 0.2 s
+Ts = 2e-3  # sampling interval: 2 ms
+N = T0/Ts  # number of samples to represent the pulse "duty cycle"
+A = 4  # pulse amplitude: 4 Volts
+pulse = A * np.hstack([np.zeros(int(N)),
+                       np.ones(int(N)), np.zeros(int(4*N))])  # pulse
+triangle = Ts*np.convolve(pulse, pulse)  # (approx.) continuous convolution
+print(f'Convolution peak at {T0} is {(A**2)*T0}')
+plt.subplots_adjust(hspace=0.4)
+myaxis = [-0.2, 0.6, -1, 5]  # show this interval
+plt.subplot(2, 1, 1)
+t = Ts * (np.arange(0, len(pulse))-N+1)  # time axis, create "negative" time(
+plt.plot(t, pulse, color='g')
+plt.ylabel('p(t)')
+plt.title('Pulse')
+plt.subplot(212)
+t = Ts*(np.arange(0, len(triangle))-2*N)
+h = plt.plot(t, triangle)
+plt.ylabel('p(t)*p(t)')
+plt.annotate(
+    'peak',
+    xy=(0.2, 3.2),
+    xytext=(0.5, 2),
+    arrowprops=dict(arrowstyle="->", facecolor='black'),
+    horizontalalignment='center', verticalalignment='bottom')
+plt.xlabel('time (s)')
+plt.title('Convolution')
+plt.show()


### PR DESCRIPTION
This pull request aimed to add in the `PythonCodeSnippets` three codes translated from `MatlabOctaveCodeSnippets`. Such as:
- snip_signals_peak_detection.m -> snip_signals_peak_detection.py
- snip_systems_ak_convolution.m -> snip_systems_ak_convolution.py 
- snip_systems_Msequence_chan_est.m -> snip_systems_Msequence_chan_est.m .py
- snip_systems_Msequence_step2.m -> snip_systems_Msequence_step2.m .py
- snip_systems_Msequence_step3.m -> snip_systems_Msequence_step3.m .py 
- snip_systems_continuos_discrete_conv.m -> snip_systems_continuous_discrete_conv.py

Furthermore, a suggestion for future works, in the snip_systems_ak_convolution.py code, there is a function called `ak_convolution2`, which would be interesting to modularize. In other words, put it into a single file. This is already done for Matlab/Octave codes since there is a file called ak_convolution2.m in the `MatlabOctaveFunctions` folder.  

Finally, I would like to suggest a revision in two Matlab/Octave: `snip_systems_Msequence_step2.m` and `snip_systems_Msequence_step3.m`. I translated both for Python, however, the purpose of each one was fuzzy to me. Especially in the snip_systems_Msequence_step2.m. There are some "magic numbers", that is, the use of constant numbers without a good explanation. 