### PR TITLE
translation of Matlab/Octave code to Python

### DIFF
--- a/MatlabOctaveCodeSnippets/snip_systems_stepinvariance.m
+++ b/MatlabOctaveCodeSnippets/snip_systems_stepinvariance.m
@@ -8,7 +8,7 @@ Bz=[0 1-exp(-a*Ts)]; %get theoretical B(z).
 Az=[1 -exp(-a*Ts)]; %get theoretical A(z)
 t=0:Ts:10; qt=1-exp(-a*t); %q(t) is the system response to u(t)
 un=ones(1,2*length(t));
-hn=impz(Bz,Az,length(ht)); %discrete-time h[n] from H(z)=Bz/Az
+hn=impz(Bz,Az,length(t)); %discrete-time h[n] from H(z)=Bz/Az
 qn=conv(un,hn);
 q_Error=qt - qn(1:length(qt)); %error from column vectors
 disp(['mean square error (MSE) = ' num2str(mean(q_Error.^2))]);

--- a/PythonCodeSnippets/snip_frequency_Levinson_Durbin.py
+++ b/PythonCodeSnippets/snip_frequency_Levinson_Durbin.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+
+def snip_frequency_Levinson_Durbin(R, p):
+    # Inicialização
+    k = np.zeros(p)
+    a = np.zeros(p)
+    E = np.zeros(p)
+    k[0] = R[1] / R[0]
+    a[0] = k[0]
+    E[0] = R[0] * (1 - k[0] ** 2)
+
+    # Recursão
+    for i in range(1, p):
+        k[i] = (R[i + 1] - np.sum(a[:i] * R[i:0:-1])) / E[i - 1]
+        a[i] = k[i]
+        a[:i] = a[:i] - k[i] * a[i - 1:: -1]
+        E[i] = E[i - 1] * (1 - k[i] ** 2)
+
+    return a, k, E
+
+
+def test_function():
+    # Defina o vetor de correlação de amostra R e a ordem de análise LPC p
+    R = np.array([1.0, 0.5, 0.2, 0.1])
+    p = 3
+    # Chame a função com R e p
+    a, k, E = snip_frequency_Levinson_Durbin(R, p)
+
+    # Imprima os resultados
+    print("Coeficientes LPC (a):", a)
+    print("Coeficientes de reflexão (k):", k)
+    print("Energias de erro (E):", E)
+
+
+test_function()

--- a/PythonCodeSnippets/snip_frequency_lpcExample.py
+++ b/PythonCodeSnippets/snip_frequency_lpcExample.py
@@ -1,0 +1,23 @@
+import numpy as np
+from scipy.signal import lfilter, lfilter_zi
+from spectrum import aryule
+
+N = 100
+x = np.random.randn(N)  # WGN witch mean and unit variance
+y = lfilter([4], [1, 0.5, 0.98], x)  # realization of an AR(2) process
+
+Py = np.mean(y**2)  # signal power
+
+A, Perror, _ = aryule(y, 2)  # estimate the filter via LPC
+
+# impulse response of 1/A(z)
+zi = lfilter_zi([1], A)
+z, _ = lfilter([1], A, np.concatenate(([1], np.zeros(499))), zi=zi * 1)
+
+Eh = np.sum(z**2)  # impulse response energy
+
+print("Py = ", Py)
+print("A = ", A)
+print("Perror = ", Perror)
+print("Eh = ", Eh)
+print(Py - (Perror * Eh))

--- a/PythonCodeSnippets/snip_systems_channel_estimation.py
+++ b/PythonCodeSnippets/snip_systems_channel_estimation.py
@@ -1,0 +1,35 @@
+import numpy as np
+from scipy.linalg import toeplitz
+
+Nx = 10  # number of samples of input training sequence
+x = np.random.randn(Nx, 1)  # arbitrary input signal, as a column vector
+
+# arbitrary channel, also as a column vector
+h = np.array([1, 0.4, 0.3, -0.2, 0.1]).reshape(-1, 1)
+
+# prepare for convolution as matrix
+first_col = np.r_[x.flatten(), np.zeros(len(h) - 1)]
+first_row = np.r_[x[0], np.zeros(len(h) - 1)]
+X = toeplitz(first_col, first_row)
+
+y = np.dot(X, h)  # pass input signal through the channel
+y = y + 0.3 * np.random.randn(*y.shape)  # add some random noise
+
+# LS estimate via M-P pseudoinverse using pinv
+h_est = np.dot(np.linalg.pinv(X), y)
+
+# alternative LS estimate via M-P pseudoinverse
+h_est2 = np.dot(np.dot(np.linalg.inv(np.dot(X.T, X)), X.T), y)
+
+# mean squared error with pinv
+MSE = np.mean(np.abs(h - h_est) ** 2)
+
+# mean squared error via property
+MSE2 = np.mean(np.abs(h - h_est2) ** 2)
+
+# normalized MSE in dB
+NMSE = 10 * np.log10(MSE / np.mean(np.abs(h) ** 2))
+
+print("MSE = ", MSE)
+print("MSE2 = ", MSE2)
+print("NMSE = ", NMSE)

--- a/PythonCodeSnippets/snip_systems_lowpass_to_pandpass.py
+++ b/PythonCodeSnippets/snip_systems_lowpass_to_pandpass.py
@@ -1,0 +1,33 @@
+from scipy import signal
+import matplotlib.pyplot as plt
+import numpy as np
+
+N = 4  # prototype order (bandpass order is 2N = 8)
+
+# prototype with cutoff=1 rad/s
+B, A = signal.butter(N, 1, 'low', analog=True)
+
+# convert to cutoff=50 and BW=30 rad/s
+Bnew, Anew = signal.lp2bp(B, A, 50, 30)
+
+# plot mag (linear scale) and phase
+w, h = signal.freqs(Bnew, Anew)
+
+plt.figure()
+plt.subplot(2, 1, 1)
+plt.semilogx(w, 20 * np.log10(abs(h)))
+plt.title('Butterworth filter frequency response')
+plt.xlabel('Frequency [radians / second]')
+plt.ylabel('Amplitude [dB]')
+plt.margins(0, 0.1)
+plt.grid(which='both', axis='both')
+plt.axvline(100, color='green')  # cutoff frequency
+plt.subplot(2, 1, 2)
+angles = np.unwrap(np.angle(h))
+plt.semilogx(w, angles)
+plt.title('Phase')
+plt.xlabel('Frequency [radians / second]')
+plt.ylabel('Phase [radians]')
+plt.grid(which='both', axis='both')
+plt.axvline(100, color='green')  # cutoff frequency
+plt.show()

--- a/PythonCodeSnippets/snip_systems_stepinvariance.py
+++ b/PythonCodeSnippets/snip_systems_stepinvariance.py
@@ -1,0 +1,37 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy import signal
+
+# # Illustrates the step invariance method to convert a single pole H(s)
+Ts = 0.5  # taxa de amostragem
+a = 10  # polo
+Bs = a
+As = [1, a]
+
+# Note the delay z^{-1} in Bz below to align u[n] with u(t).
+# Try using Bz = [1 - np.exp(-a * Ts)] instead.
+Bz = [0, 1 - np.exp(-a * Ts)]
+Az = [1, -np.exp(-a * Ts)]
+
+t = np.arange(0, 10 + Ts, Ts)
+qt = 1 - np.exp(-a * t)  # q(t) is the system response to u(t)
+
+un = np.ones(2 * len(t))
+
+# Converting the transfer function to
+# state space to use with dimpulse
+s1 = signal.dlti(Bz, Az, dt=Ts)
+t, hn = signal.dimpulse(s1, n=len(t))
+
+hn = hn[0][:, 0]
+
+qn = np.convolve(un, hn, mode="full")[: len(t)]
+q_Error = qt - qn
+
+print(f"mean square error (MSE) = {np.mean(q_Error**2)}")
+
+plt.plot(t, qt)
+plt.plot(t, qn, "rx")  # comparar curvas
+plt.legend(["q(t)", "q[n]"])
+plt.xlabel("time (s)")
+plt.show()


### PR DESCRIPTION
The following codes have been translated to Python:
The Spectrum library was added to the snip_frequency_lpcExample.py file because I couldn't find an alternative to estimate the filter via LPC.
- snip_frequency_lpcExample.m  
- snip_frequency_Levinson_Durbin.m
- snip_systems_stepinvariance.py 
- snip_systems_lowpass_to_pandpass.py
- snip_snip_systems_channel_estimation 
