### PR TITLE
Translation Matlab to Python

### DIFF
--- a/PythonCodeSnippets/snip_frequency_comparePeriodograms.py
+++ b/PythonCodeSnippets/snip_frequency_comparePeriodograms.py
@@ -1,0 +1,30 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.signal import periodogram
+
+N = 1024
+n = np.arange(N)  # Column vector in MATLAB, but numpy makes no distinction
+A = 10
+x = A * np.cos((2 * np.pi / 64) * n)  # Generates cosine with period 64
+
+BW = 2 * np.pi  # Assumed bandwidth
+S = np.abs(np.fft.fft(x)) ** 2 / (BW * N)  # Periodogram
+
+# Avoids zero-padding in the periodogram:
+Nfft = N
+f, H = periodogram(x, fs=BW, nfft=Nfft, scaling="density")
+
+Power = np.sum(H) * BW / N  # Power from unilateral periodogram
+Power2 = np.sum(S) * BW / N  # Power from bilateral periodogram
+
+# Conversion from bilateral to unilateral:
+Sunilateral = np.concatenate(([S[0]], 2 * S[1 : N // 2], [S[N // 2]]))
+
+print(f"Power from unilateral periodogram: {Power}")
+print(f"Power from bilateral periodogram: {Power2}")
+
+# Comparison of periodograms
+plt.plot(f, H, "-o", label="Periodogram")
+plt.plot(f, Sunilateral, "-x", label="Bilateral to Unilateral Conversion")
+plt.legend()
+plt.show()

--- a/PythonCodeSnippets/snip_frequency_correctPeriodograms.py
+++ b/PythonCodeSnippets/snip_frequency_correctPeriodograms.py
@@ -1,0 +1,33 @@
+import numpy as np
+from scipy.signal import periodogram
+from numpy.fft import fftshift
+
+# Defining variables
+N = 1024
+n = np.arange(N)  # Column vector n
+A = 10
+x = A * np.cos((2 * np.pi / 64) * n)  # Generating cosine with period 64
+Fs = 500  # Fs = BW = 500 Hz
+BW = Fs
+
+# Unilateral periodogram
+f, H = periodogram(x, Fs, nfft=N, return_onesided=True)
+
+# Bilateral periodogram with frequency range adjustment
+f2, H2 = periodogram(x, Fs, nfft=N, return_onesided=False)
+# Adjusting the frequency range to [0, Fs) using fftshift
+H2 = fftshift(H2)
+f2 = np.linspace(0, Fs, N, endpoint=False)
+
+# Power for the unilateral periodogram
+Power = (BW / N) * np.sum(H)
+
+# Power for the bilateral periodogram
+Power2 = (BW / N) * np.sum(H2)
+
+print(f"Power = {Power}")
+print(f"Power2 = {Power2}")
+print(f"ans = {f[-1]}")
+print(f"ans = {f2[-1]}")
+print(f"ans = {len(f)}")
+print(f"ans = {len(f2)}")

--- a/PythonCodeSnippets/snip_signals_three_rects.py
+++ b/PythonCodeSnippets/snip_signals_three_rects.py
@@ -1,0 +1,24 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+def rectpuls(t, width):
+    """Generates a rectangular pulse with specified width."""
+    return np.where(np.abs(t) <= width / 2, 1, 0)
+
+# Sampling interval in seconds
+Ts = 0.001
+# Discrete time in seconds
+t = np.arange(-1.6, 1.6, Ts)
+# Support width of this rectangle in seconds
+pulse_width = 0.2
+# Defines the signal
+x = (
+    rectpuls(t, pulse_width)
+    - 3 * rectpuls(t - 0.2, pulse_width)
+    + 3 * rectpuls(t - 0.4, pulse_width)
+)
+# Plots as a continuous signal
+plt.plot(t, x)
+plt.xlabel("t")
+plt.ylabel("x(t)")
+plt.show()

--- a/PythonCodeSnippets/snip_systems_Matlab_coefficient_quantization.py
+++ b/PythonCodeSnippets/snip_systems_Matlab_coefficient_quantization.py
@@ -1,0 +1,30 @@
+import numpy as np
+from scipy import signal
+import matplotlib.pyplot as plt
+
+bi = 7  # number of bits for integer part
+bf = 8  # number of bits for decimal part
+b = bi + bf + 1  # total number of bits, including sign bit
+signed = 1  # use signed numbers (i.e., not "unsigned")
+
+Bq = np.around(B, decimals=bf)  # quantize coefficients of B(z) using Q7.8
+Aq = np.around(A, decimals=bf)  # quantize coefficients of A(z) using Q7.8
+
+# Get the poles and zeros
+zeros, poles, _ = signal.tf2zpk(Bq, Aq)
+
+# Plot the poles and zeros
+plt.figure()
+plt.plot(np.real(zeros), np.imag(zeros), "o")
+plt.plot(np.real(poles), np.imag(poles), "x")
+
+# Add a unit circle for reference
+unit_circle = plt.Circle((0, 0), 1, color="black", fill=False)
+plt.gca().add_artist(unit_circle)
+
+plt.title("Poles and Zeros")
+plt.xlabel("Real")
+plt.ylabel("Imaginary")
+plt.axis("equal")
+plt.grid()
+plt.show()

--- a/PythonCodeSnippets/snip_systems_circularConvolution.py
+++ b/PythonCodeSnippets/snip_systems_circularConvolution.py
@@ -1,0 +1,31 @@
+import numpy as np
+from scipy.signal import convolve
+
+# Signals to be convolved
+x = np.array([1, 2, 3, 4])
+h = np.array([0.9, 0.8])
+
+# Deciding whether to make linear and circular convolution equivalent
+shouldMakeEquivalent = 1
+
+# Determining the size for zero-padding
+if shouldMakeEquivalent == 1:
+    N = (
+        len(x) + len(h) - 1
+    )  # To force the match between linear and circular convolution
+else:
+    N = max(len(x), len(h))  # Necessary for FFT zero-padding
+
+# Linear convolution
+linearConv = convolve(x, h, mode="full")
+
+# Circular convolution using FFT
+x_padded = np.fft.fft(x, n=N)
+h_padded = np.fft.fft(h, n=N)
+circularConv = np.fft.ifft(x_padded * h_padded)
+
+print("shouldMakeEquivalent =\n", shouldMakeEquivalent)
+print("\nlinearConv =\n", linearConv)
+print(
+    "\ncircularConv =\n", np.real(circularConv)
+)  # The real part is shown, ignoring the small imaginary part


### PR DESCRIPTION
snip_signals_three_rects.py
snip_systems_circularConvolution.py
snip_systems_Matlab_coefficient_quantization.py
snip_frequency_comparePeriodograms.py
snip_frequency_correctPeriodograms.py

Obs: I needed to make a shift in the code: snip_frequency_correctPeriodograms.py, because the periodogram function in MATLAB works from 0 up to the sampling rate Fs, and in Python, when return_onesided is False, the function works between -Fs/2 to Fs/2. Therefore, to make the output the same, I had to manually adjust it using the Python function "fftshift". Thus, both codes return the same response.